### PR TITLE
WIP: Verbeter volgorde onderdelen datastandaard

### DIFF
--- a/spdp-fiets/docs/1-informatiemodel.md
+++ b/spdp-fiets/docs/1-informatiemodel.md
@@ -130,13 +130,27 @@ De velden surveyId, authorityId en contractorId kunnen gebruikt worden bij het f
 Je zou bijvoorbeeld kunnen alle metingen van een bepaald onderzoek die zijn uitgevoerd door een bepaalde contractor kunnen opvragen. Zie *API Requests* voor meer details over zoekopdrachten.
 
 
-### Space - definiëring van een plek aan de hand van properties
+### Space
+
+Definiëring van een plek aan de hand van properties
 
 | Field                | Type               | Required                | Description                                                 |
 | -------------------- | ------------------ | ----------------------- | ------------------------------------------------------------|
 | `type`               | string             | no                      | SpaceTypeID; tenminste 1 veld dient gegeven te zijn            |
 | `level`              | number             | no                      | 0=onder, 1=boven                                            |
 | `vehicles`           | Vehicle[]          | no                      | Deze space is uitsluitend geschikt voor genoemde voertuigen |
+|{.data}
+
+#### spaceTypeIDs
+
+| ID | spaceType             |
+| -- | --------------------- |
+| `x`  | buiten voorziening    |
+| `r`  | rek                   |
+| `n`  | nietjes               |
+| `v`  | vak                   |
+| `w`  | voor fietsenwinkel    |
+| `a`  | anders                |
 |{.data}
 
 ### Vehicle
@@ -151,7 +165,7 @@ Je zou bijvoorbeeld kunnen alle metingen van een bepaald onderzoek die zijn uitg
 | `owner`              | string             | no                     | Zie tabel vehicle.owner                                      |
 |{.data}
 
-### Accessoire
+#### Accessoire
 
 | Field                | Type               | Required               | Description                                                  |
 | -------------------- | ------------------ | ---------------------- | ------------------------------------------------------------ |
@@ -159,14 +173,96 @@ Je zou bijvoorbeeld kunnen alle metingen van een bepaald onderzoek die zijn uitg
 | `position`           | string             | no                     | Zie tabel vehicle.accessoire.positions                      |
 |{.data}
 
+##### vehicle.accessoire.typen 
 
-### VehicleState
+| ID | Omschrijving          |
+| -- | --------------------- |
+| `z`  | zitje                 |
+| `t`  | fietstas              |
+| `r`  | rek                   |
+| `b`  | bak / mand            |
+|{.data}
+
+##### vehicle.accessoire.positions 
+
+| ID | Omschrijving          |
+| -- | --------------------- |
+| `v`  | voor                  |
+| `a`  | achter                |
+|{.data}
+
+
+#### VehicleState
 
 | Field                | Type               | Required               | Description                                                  |
 | -------------------- | ------------------ | ---------------------- | ------------------------------------------------------------ |
-|`type`                | string             | no                     | Zie tabel vehicle.state.typen                          |
-|`position`            | string             | no                     | Zie tabel vehicle.state.positions                      |
+|`type`                | string             | no                     | Zie tabel vehicle.state.type                          |
+|`position`            | string             | no                     | Zie tabel vehicle.state.position                      |
 |{.data}
+
+##### vehicle.state.type 
+
+| ID | Omschrijving          |
+| -- | --------------------- |
+| `w`  | wrak                  |
+| `l`  | lekke band            |
+| `z`  | zonder zadel          |
+| ...| ...                   |
+|{.data}
+
+##### vehicle.state.position
+
+| ID | Omschrijving          |
+| -- | --------------------- |
+| `v`  | voor                  |
+| `a`  | achter                |
+|{.data}
+
+Onderstaande lijstjes geven de mogelijk waarden die voor diverse velden mogelijk zijn. Lijstjes die eindigen met ... zijn voor uitbreiding vatbaar.
+
+#### vehicle.parkState
+
+| ID | Omschrijving          |
+| -- | --------------------- |
+| `n`  | naast voorziening     |
+| `d`  | dubbel                |
+| ...| ...                   |
+|{.data}
+
+#### vehicle.type
+
+| ID | Voertuigtype          | Omschrijving                                                                   |
+| -- | --------------------- | ------------------------------------------------------------------------------ |
+| `f`  | fiets                 | Geen kenteken en geen verzekeringsplaatje                                      |
+| `c`  | bakfiets              | Fiets met bak                                                                  |
+| `s`  | snorfiets             | kentekenplaat is blauw, met een wit kader, wit opschrift en een hologram       |
+| `b`  | bromfiets             | kentekenplaat is geel, met een zwart kader, zwart opschrift en een hologram    |
+| `m`  | motorfiets            | NL geel of blauw, internationaal anders                                        |
+| `g`  | gehandicaptenvoertuig | driewieler, scootmobiel, rolstoel, etc                                         |
+| `a`  | anders                |                                                                                |
+|{.data}
+
+#### vehicle.propulsion
+
+| ID | Aandrijving     | Omschrijving                                                                   |
+| -- | --------------- | ------------------------------------------------------------------------------ |
+| `s`  | Spierkracht     | bv traditionele fiets of voetganger                                            |
+| `e`  | Elektrisch      | bv e-bike                                                                      |
+| `b`  | Brandstof       | bv traditionele bromfiets, motorfiets                                          | 
+|{.data}
+
+#### vehicle.owner
+
+| ID | Eigenaar              | Omschrijving                                                                   |
+| -- | --------------------- | ------------------------------------------------------------------------------ |
+| `p`  | Privé                 | Privéfiets                                                                     |
+| `l`  | Lease                 | Leasefiets, zoals Swap Bikes                                                   |
+| `h`  | Huur                  | Huurfiets, zoals OV-fiets                                                      |
+|{.data}
+
+De velden `parkingCapacity`, `vacantSpaces` en `occupiedSpaces` en `count` zijn verplicht in de bladeren van de sectieboom  
+
+Indien ze in de takken niet gegeven zijn, kunnen `vacantSpaces`, `occupiedSpaces` en `occupation` berekend worden door alle `vacantSpaces`, etc. van onderliggende sections op te tellen
 
 ### Count
 
@@ -186,97 +282,3 @@ Je zou bijvoorbeeld kunnen alle metingen van een bepaald onderzoek die zijn uitg
 |`isUnderConstruction`| boolean             | no                     | Werkzaamheden?                                               |
 |`remark`             | string              | no                     | Vrij tekstveld                                               |
 |{.data}
-
-Onderstaande lijstjes geven de mogelijk waarden die voor diverse velden mogelijk zijn. Lijstjes die eindigen met ... zijn voor uitbreiding vatbaar.
-
-### spaceTypeIDs
-
-| ID | spaceType             |
-| -- | --------------------- |
-| `x`  | buiten voorziening    |
-| `r`  | rek                   |
-| `n`  | nietjes               |
-| `v`  | vak                   |
-| `w`  | voor fietsenwinkel    |
-| `a`  | anders                |
-|{.data}
-
-### vehicle.accessoire.typen 
-
-| ID | Omschrijving          |
-| -- | --------------------- |
-| `z`  | zitje                 |
-| `t`  | fietstas              |
-| `r`  | rek                   |
-| `b`  | bak / mand            |
-|{.data}
-
-### vehicle.accessoire.positions 
-
-| ID | Omschrijving          |
-| -- | --------------------- |
-| `v`  | voor                  |
-| `a`  | achter                |
-|{.data}
-
-### vehicle.state.type 
-
-| ID | Omschrijving          |
-| -- | --------------------- |
-| `w`  | wrak                  |
-| `l`  | lekke band            |
-| `z`  | zonder zadel          |
-| ...| ...                   |
-|{.data}
-
-### vehicle.state.position
-
-| ID | Omschrijving          |
-| -- | --------------------- |
-| `v`  | voor                  |
-| `a`  | achter                |
-|{.data}
-
-### vehicle.parkState
-
-| ID | Omschrijving          |
-| -- | --------------------- |
-| `n`  | naast voorziening     |
-| `d`  | dubbel                |
-| ...| ...                   |
-|{.data}
-
-### vehicle.type
-
-| ID | Voertuigtype          | Omschrijving                                                                   |
-| -- | --------------------- | ------------------------------------------------------------------------------ |
-| `f`  | fiets                 | Geen kenteken en geen verzekeringsplaatje                                      |
-| `c`  | bakfiets              | Fiets met bak                                                                  |
-| `s`  | snorfiets             | kentekenplaat is blauw, met een wit kader, wit opschrift en een hologram       |
-| `b`  | bromfiets             | kentekenplaat is geel, met een zwart kader, zwart opschrift en een hologram    |
-| `m`  | motorfiets            | NL geel of blauw, internationaal anders                                        |
-| `g`  | gehandicaptenvoertuig | driewieler, scootmobiel, rolstoel, etc                                         |
-| `a`  | anders                |                                                                                |
-|{.data}
-
-### vehicle.propulsion
-
-| ID | Aandrijving     | Omschrijving                                                                   |
-| -- | --------------- | ------------------------------------------------------------------------------ |
-| `s`  | Spierkracht     | bv traditionele fiets of voetganger                                            |
-| `e`  | Elektrisch      | bv e-bike                                                                      |
-| `b`  | Brandstof       | bv traditionele bromfiets, motorfiets                                          | 
-|{.data}
-
-### vehicle.owner
-
-| ID | Eigenaar              | Omschrijving                                                                   |
-| -- | --------------------- | ------------------------------------------------------------------------------ |
-| `p`  | Privé                 | Privéfiets                                                                     |
-| `l`  | Lease                 | Leasefiets, zoals Swap Bikes                                                   |
-| `h`  | Huur                  | Huurfiets, zoals OV-fiets                                                      |
-|{.data}
-
-De velden `parkingCapacity`, `vacantSpaces` en `occupiedSpaces` en `count` zijn verplicht in de bladeren van de sectieboom  
-
-Indien ze in de takken niet gegeven zijn, kunnen `vacantSpaces`, `occupiedSpaces` en `occupation` berekend worden door alle `vacantSpaces`, etc. van onderliggende sections op te tellen

--- a/spdp-fiets/docs/2-api.md
+++ b/spdp-fiets/docs/2-api.md
@@ -1,5 +1,5 @@
 ## API- requests
-### algemene regels
+### Algemeen
 Alle GET-requests moeten in een wrapper-object gestoken worden met het resultaat in een property 'result'.  
 Dus `GET /staticdata`:  
 Respons:  
@@ -31,8 +31,8 @@ De datastandaard schrijft voor dat data in elk geval in afzonderlijke blokken Su
 
 Alle genoemde requests beginnen met een /. Voor deze schuine streep komt uiteraard de base-url van de API. In het geval van de pilot in VeiligStallen is de base-url https://remote.veiligstallen2.nl/rest/api
 
-### Metingen groeperen in 1 onderzoek (= 'survey')  
-#### Stap 1: zorg dat alle betrokken partijen (opdrachtgevers/authorities, tellers/contractors) bekend zijn bij de dataportal
+#### Metingen groeperen in 1 onderzoek (= 'survey')  
+##### Stap 1: zorg dat alle betrokken partijen (opdrachtgevers/authorities, tellers/contractors) bekend zijn bij de dataportal
 Check met 
 `GET /organisations` welke instanties er al bekend zijn.  
 [Response](./examples/API3/responses/GET_organisations.json)  
@@ -46,7 +46,7 @@ Mis je instanties, voeg ze toe met:
 <pre class='example json' title="Body (zonder surveyId)" data-include='../examples/API3/requests/POST_new_organisation.json' data-include-format='text'></pre>
 <pre class='example json' title="Response" data-include='../examples/API3/responses/POST_new_organisation.json' data-include-format='text'></pre>
 
-#### Stap 2: meld je onderzoek (survey) aan
+##### Stap 2: meld je onderzoek (survey) aan
 `POST /surveys` [Body met surveyId](./examples/API3/requests/POST_new_survey_with_id.json)  
 Een id van de survey mag door exploitant zelf gekozen worden. Suggestie gebruik [CBS codes](https://www.cbs.nl/nl-nl/onze-diensten/methoden/classificaties/overig/gemeentelijke-indelingen-per-jaar/indeling-per-jaar/gemeentelijke-indeling-op-1-januari-2020) en unieke gegevens uit het onderzoek, bijv. < CBS_nr_gemeente >_< jaartal > => 0202_2020.  
 
@@ -65,7 +65,7 @@ Indien geen `surveyId` is gegeven, maakt de server zelf een id en geeft deze ter
 <pre class='example json' title="Response" data-include='../examples/API3/responses/POST_new_survey.json' data-include-format='text'></pre>
 
 
-#### Stap 3: koppel statische data aan bestaand onderzoek
+##### Stap 3: koppel statische data aan bestaand onderzoek
 `POST /staticdata` [Body](./examples/API3/requests/POST_static_data.json)  
 
 <pre class='example json' title="Body" data-include='../examples/API3/requests/POST_static_data.json' data-include-format='text'></pre>
@@ -76,7 +76,7 @@ Zonder het veld `surveyId` worden de statische secties niet gekoppeld aan een on
 
 Het Id van een statische sectie is, net als het `surveyID`, door de opsturende instantie zelf samen te stellen. Suggestie: prefix het sectionId met het surveyId om een unieke id te garanderen, bijvoorbeeld: `< surveyId >_< straatnaam >`
 
-### Stap 3: Sla losse metingen op
+##### Stap 3: Sla losse metingen op
 `POST /dynamicdata` [Body](./examples/API3/requests/POST_dynamic_data.json)
 
 <pre class='example json' title="Body" data-include='../examples/API3/requests/POST_dynamic_data.json' data-include-format='text'></pre>
@@ -161,7 +161,7 @@ Dynamische data moet gesorteerd kunnen worden opgevraagd. Dat kan met de paramet
 `dynamicdata?orderBy=timestamp&orderDirection=ASC` - sorteert op timestamp van oudste naar nieuwste  
 `dynamicdata?orderBy=count.numberOfVehicles&orderDirection=DESC` - sorteert op aantal voertuigen van hoog naar laag  
 
-### Een overzicht van alle query parameters
+#### Een overzicht van alle query parameters
 | param             | type        | values                                                 |
 | ----------------- |---------- | ----------------------------------------------------- |
 | `surveyid`            | string    | Alleen data van dit onderzoek                            |

--- a/spdp-fiets/docs/3-voorbeelden.md
+++ b/spdp-fiets/docs/3-voorbeelden.md
@@ -106,34 +106,13 @@ In de *Dorpsstraat*, te *Ons Dorp*,  staat een fietsenrek met 8 plekken, waarin 
 De straat is een sectie. 
 Deze exacte locatie daarvan wordt vastgelegd in de statische data, bijvoorbeeld:  
 
+<div class='example'>
+
 ```json
 "id": "Dorpsstraat_OnsDorp"
 "naam": "Dorpsstraat"
-"geoLocation": "Polygon[ hier een reeks coördinaten ]  "
+"geoLocation": ...
 ```
-
-<div class='issue'>
-
-Moet bij `geoLocation` een volgende JSON-object worden ingevoegd? Want hoe het hierboven staat, lijkt het eerder een WKT-string.
-
-```json
-{
-  "type": "Feature",
-  "geometry": {
-      "type": "Polygon",
-      "coordinates": [
-          [
-              [100.0, 0.0],
-              [101.0, 0.0],
-              [101.0, 1.0],
-              [100.0, 1.0],
-              [100.0, 0.0]
-          ]
-      ]
-  },
-}
-```
-
 </div>
 
 De dynamische data kan er visueel zo uit zien, als de tellers zeer gedetailleerd te werk gaan. Zo kan bijvoorbeeld zelfs worden aangegeven dat één van de fietsen in het rek een lekke band heeft.


### PR DESCRIPTION
Deze PR voert geen inhoudelijke wijzigingen door aan de datastandaard fietsparkeren.

Het wijzigt wel de wijze en volgorde waarop de onderdelen daarvan gepresenteerd worden.